### PR TITLE
Fix pubmedclip

### DIFF
--- a/src/mmshap_medclip/comparison.py
+++ b/src/mmshap_medclip/comparison.py
@@ -337,34 +337,34 @@ def plot_comparison_simple(
             grid_w = n_patches // grid_h
 
         patch_grid = img_vals[:grid_h * grid_w].reshape(grid_h, grid_w)
-        
+
         # Replicar el grid a una resolución más alta si tiene pocos parches
         # Esto asegura que modelos con patch_size grande (como PubMedCLIP con patch32)
         # tengan la misma granularidad visual que modelos con patch_size pequeño (como BioMedCLIP con patch16)
         # Usamos replicación en lugar de interpolación para mantener la apariencia de parches discretos
         target_grid_size = 14  # Tamaño objetivo para que coincida con modelos patch16 (224/16 = 14)
         h_orig, w_orig = patch_grid.shape[0], patch_grid.shape[1]
-        
+
         # DEBUG: Log información del modelo y grid original
         print(f"[DEBUG comparison.py] Modelo: {model_name} | Grid original: {h_orig}x{w_orig} | Target: {target_grid_size}x{target_grid_size}")
-        
+
         # Forzar replicación si el grid es más pequeño que el objetivo
         if h_orig < target_grid_size or w_orig < target_grid_size:
             # Calcular el factor de replicación necesario (redondear hacia arriba)
             h_scale = int(np.ceil(target_grid_size / h_orig)) if h_orig > 0 else 1
             w_scale = int(np.ceil(target_grid_size / w_orig)) if w_orig > 0 else 1
-            
+
             print(f"[DEBUG comparison.py] ✅ REPLICANDO: {h_orig}x{w_orig} -> {target_grid_size}x{target_grid_size} (escalas: h={h_scale}, w={w_scale})")
-            
+
             # Replicar cada parche usando repeat_interleave para mantener parches discretos
             patch_grid_tensor = torch.as_tensor(patch_grid, dtype=torch.float32)
             # Replicar en altura: cada fila se repite h_scale veces
             patch_grid_tensor = patch_grid_tensor.repeat_interleave(h_scale, dim=0)
             # Replicar en ancho: cada columna se repite w_scale veces
             patch_grid_tensor = patch_grid_tensor.repeat_interleave(w_scale, dim=1)
-            
+
             print(f"[DEBUG comparison.py] Después de repeat_interleave: {patch_grid_tensor.shape[0]}x{patch_grid_tensor.shape[1]}")
-            
+
             # Asegurar que tenga exactamente el tamaño objetivo
             if patch_grid_tensor.shape[0] > target_grid_size:
                 patch_grid_tensor = patch_grid_tensor[:target_grid_size, :]
@@ -381,7 +381,7 @@ def plot_comparison_simple(
             print(f"[DEBUG comparison.py] Grid final después de replicación: {patch_grid.shape[0]}x{patch_grid.shape[1]}")
         else:
             print(f"[DEBUG comparison.py] ⏭️  NO se replica (grid ya es {h_orig}x{w_orig} >= {target_grid_size}x{target_grid_size})")
-        
+
         heat_tensor = torch.as_tensor(patch_grid, dtype=torch.float32).unsqueeze(0).unsqueeze(0)
         heat_up = F.interpolate(heat_tensor, size=(H, W), mode='nearest').squeeze().numpy()
 

--- a/src/mmshap_medclip/comparison.py
+++ b/src/mmshap_medclip/comparison.py
@@ -390,10 +390,16 @@ def plot_comparison_simple(
         vmax = max(vmax, 1e-6)
         norm_img = TwoSlopeNorm(vmin=-vmax, vcenter=0.0, vmax=vmax)
 
+        # Alpha consistente para todos los modelos (igual que en heatmaps.py)
+        # Verificar si este modelo tiene replicación para ajustar ligeramente
+        alpha_consistent = 0.40  # Alpha base consistente
+        # Nota: En comparison.py no tenemos el flag was_replicated, así que usamos alpha fijo
+        # La normalización por percentil ya ayuda a mantener consistencia visual
+
         # Mostrar imagen con overlay
         ax_img.imshow(img_vis, origin='upper', interpolation='nearest')
         ax_img.imshow(
-            heat_up, cmap='coolwarm', norm=norm_img, alpha=0.4,
+            heat_up, cmap='coolwarm', norm=norm_img, alpha=alpha_consistent,
             origin='upper', interpolation='nearest'
         )
 

--- a/src/mmshap_medclip/vis/heatmaps.py
+++ b/src/mmshap_medclip/vis/heatmaps.py
@@ -932,6 +932,10 @@ def plot_text_image_heatmaps(
             # Reducir alpha más agresivamente para parches replicados
             # Aplicar reducción del 60% (multiplicar por 0.4) para que coincida mejor con otros modelos
             alpha_to_use = alpha_to_use * 0.4
+        else:
+            # Para modelos sin replicación, aumentar ligeramente el alpha para igualar con PubMedCLIP
+            # Aumentar en ~15% para mejorar visibilidad y balance
+            alpha_to_use = alpha_to_use * 1.15
 
         ax.imshow(
             heat_up,

--- a/src/mmshap_medclip/vis/heatmaps.py
+++ b/src/mmshap_medclip/vis/heatmaps.py
@@ -930,8 +930,8 @@ def plot_text_image_heatmaps(
         # Los parches replicados se ven más intensos porque tienen más área, así que reducimos más el alpha
         if hasattr(entry, 'was_replicated') and entry.get('was_replicated', False):
             # Reducir alpha más agresivamente para parches replicados
-            # Aplicar reducción del 60% (multiplicar por 0.4) para que coincida mejor con otros modelos
-            alpha_to_use = alpha_to_use * 0.4
+            # Aplicar reducción del 70% (multiplicar por 0.3) para que coincida mejor con otros modelos
+            alpha_to_use = alpha_to_use * 0.3
         else:
             # Para modelos sin replicación, aumentar ligeramente el alpha para igualar con PubMedCLIP
             # Aumentar en ~15% para mejorar visibilidad y balance

--- a/src/mmshap_medclip/vis/heatmaps.py
+++ b/src/mmshap_medclip/vis/heatmaps.py
@@ -929,8 +929,9 @@ def plot_text_image_heatmaps(
         # Si el grid fue replicado (de 7x7 a 14x14), reducir alpha significativamente para igualar intensidad con otros modelos
         # Los parches replicados se ven más intensos porque tienen más área, así que reducimos más el alpha
         if hasattr(entry, 'was_replicated') and entry.get('was_replicated', False):
-            # Reducir alpha en ~50% para parches replicados (de 0.75 a 0.5)
-            alpha_to_use = alpha_to_use * 0.5
+            # Reducir alpha más agresivamente para parches replicados
+            # Aplicar reducción del 60% (multiplicar por 0.4) para que coincida mejor con otros modelos
+            alpha_to_use = alpha_to_use * 0.4
 
         ax.imshow(
             heat_up,

--- a/src/mmshap_medclip/vis/heatmaps.py
+++ b/src/mmshap_medclip/vis/heatmaps.py
@@ -16,7 +16,7 @@ _CLIP_MEAN = torch.tensor([0.48145466, 0.4578275, 0.40821073], dtype=torch.float
 _CLIP_STD = torch.tensor([0.26862954, 0.26130258, 0.27577711], dtype=torch.float32)
 
 PLOT_ISA_IMG_PERCENTILE = 90   # escala robusta al percentil 90
-PLOT_ISA_ALPHA_IMG = 0.30      # opacidad del overlay (reducida para mejor visibilidad)
+PLOT_ISA_ALPHA_IMG = 0.50      # opacidad del overlay (reducida para mejor visibilidad)
 PLOT_ISA_COARSEN_G = 2        # tamaño de super-parches (3x3)
 
 
@@ -931,7 +931,7 @@ def plot_text_image_heatmaps(
         if hasattr(entry, 'was_replicated') and entry.get('was_replicated', False):
             # Reducir alpha más agresivamente para parches replicados
             # Aplicar reducción del 70% (multiplicar por 0.3) para que coincida mejor con otros modelos
-            alpha_to_use = alpha_to_use * 0.3
+            alpha_to_use = alpha_to_use * 0.1
         else:
             # Para modelos sin replicación, aumentar ligeramente el alpha para igualar con PubMedCLIP
             # Aumentar en ~15% para mejorar visibilidad y balance

--- a/src/mmshap_medclip/vis/heatmaps.py
+++ b/src/mmshap_medclip/vis/heatmaps.py
@@ -475,11 +475,14 @@ def plot_text_image_heatmaps(
         norm_text = Normalize(vmin=0.0, vmax=vmax_text)
         cmap_text = plt.get_cmap("Reds")
 
+    # Alpha base consistente para todos los modelos
+    # Usar un valor fijo para asegurar intensidad visual uniforme
     alpha_overlay = (
         float(alpha_img)
         if alpha_img is not None
         else float(PLOT_ISA_ALPHA_IMG)
     )
+    # Asegurar que el alpha esté en un rango razonable y consistente
     alpha_overlay = min(max(alpha_overlay, 0.0), 1.0)
     coarsen_factor = int(PLOT_ISA_COARSEN_G) if PLOT_ISA_COARSEN_G else 0
     percentile_img = float(PLOT_ISA_IMG_PERCENTILE)
@@ -922,20 +925,19 @@ def plot_text_image_heatmaps(
         H = entry["H"]
         W = entry["W"]
 
-        # Ajustar alpha: reducir si se aplicó replicación para que coincida con otros modelos
-        # Los parches replicados pueden verse más intensos, así que reducimos el alpha
-        alpha_to_use = min(alpha_overlay * 1.3, 0.6) if vmax_img < 1.0 else alpha_overlay
+        # Normalización de alpha para intensidad consistente entre todos los modelos
+        # Usar un alpha base fijo para todos los modelos, con ajuste mínimo solo para replicación
+        # Esto asegura que la intensidad visual sea similar independientemente de los valores SHAP
+        alpha_base = alpha_overlay  # Usar el alpha base sin ajustes por vmax_img
         
-        # Si el grid fue replicado (de 7x7 a 14x14), reducir alpha significativamente para igualar intensidad con otros modelos
-        # Los parches replicados se ven más intensos porque tienen más área, así que reducimos más el alpha
+        # Si el grid fue replicado (de 7x7 a 14x14), reducir alpha ligeramente
+        # Los parches replicados pueden verse ligeramente más intensos, así que ajustamos mínimamente
         if hasattr(entry, 'was_replicated') and entry.get('was_replicated', False):
-            # Reducir alpha más agresivamente para parches replicados
-            # Aplicar reducción del 70% (multiplicar por 0.3) para que coincida mejor con otros modelos
-            alpha_to_use = alpha_to_use * 0.1
+            # Reducción mínima del 10% para parches replicados
+            alpha_to_use = alpha_base * 0.9
         else:
-            # Para modelos sin replicación, aumentar ligeramente el alpha para igualar con PubMedCLIP
-            # Aumentar en ~15% para mejorar visibilidad y balance
-            alpha_to_use = alpha_to_use * 1.15
+            # Para modelos sin replicación, usar el alpha base directamente
+            alpha_to_use = alpha_base
 
         ax.imshow(
             heat_up,

--- a/src/mmshap_medclip/vis/heatmaps.py
+++ b/src/mmshap_medclip/vis/heatmaps.py
@@ -926,11 +926,11 @@ def plot_text_image_heatmaps(
         # Los parches replicados pueden verse más intensos, así que reducimos el alpha
         alpha_to_use = min(alpha_overlay * 1.3, 0.6) if vmax_img < 1.0 else alpha_overlay
         
-        # Si el grid fue replicado (de 7x7 a 14x14), reducir alpha para igualar intensidad con otros modelos
-        # Usar un factor de reducción basado en la relación de replicación
+        # Si el grid fue replicado (de 7x7 a 14x14), reducir alpha significativamente para igualar intensidad con otros modelos
+        # Los parches replicados se ven más intensos porque tienen más área, así que reducimos más el alpha
         if hasattr(entry, 'was_replicated') and entry.get('was_replicated', False):
-            # Reducir alpha en ~25% para parches replicados
-            alpha_to_use = alpha_to_use * 0.75
+            # Reducir alpha en ~50% para parches replicados (de 0.75 a 0.5)
+            alpha_to_use = alpha_to_use * 0.5
 
         ax.imshow(
             heat_up,

--- a/src/mmshap_medclip/vis/heatmaps.py
+++ b/src/mmshap_medclip/vis/heatmaps.py
@@ -570,19 +570,34 @@ def plot_text_image_heatmaps(
                     coarsen_factor,
                 ).mean(axis=(1, 3))
 
-        # Interpolar el grid a una resolución más alta si tiene pocos parches
+        # Replicar el grid a una resolución más alta si tiene pocos parches
         # Esto asegura que modelos con patch_size grande (como PubMedCLIP con patch32)
         # tengan la misma granularidad visual que modelos con patch_size pequeño (como BioMedCLIP con patch16)
+        # Usamos replicación en lugar de interpolación para mantener la apariencia de parches discretos
         target_grid_size = 14  # Tamaño objetivo para que coincida con modelos patch16 (224/16 = 14)
         if grid_vis.shape[0] < target_grid_size or grid_vis.shape[1] < target_grid_size:
-            # Interpolar el grid a la resolución objetivo antes de interpolar a la imagen
-            grid_vis_tensor = torch.as_tensor(grid_vis, dtype=torch.float32).unsqueeze(0).unsqueeze(0)
-            grid_vis = F.interpolate(
-                grid_vis_tensor, 
-                size=(target_grid_size, target_grid_size), 
-                mode="bilinear", 
-                align_corners=False
-            ).squeeze().numpy()
+            # Calcular el factor de replicación necesario
+            h_orig, w_orig = grid_vis.shape[0], grid_vis.shape[1]
+            h_scale = target_grid_size / h_orig
+            w_scale = target_grid_size / w_orig
+            
+            # Replicar cada parche usando repeat_interleave para mantener parches discretos
+            grid_vis_tensor = torch.as_tensor(grid_vis, dtype=torch.float32)
+            # Replicar en altura
+            grid_vis_tensor = grid_vis_tensor.repeat_interleave(int(np.ceil(h_scale)), dim=0)
+            # Replicar en ancho
+            grid_vis_tensor = grid_vis_tensor.repeat_interleave(int(np.ceil(w_scale)), dim=1)
+            # Asegurar que tenga exactamente el tamaño objetivo
+            if grid_vis_tensor.shape[0] > target_grid_size:
+                grid_vis_tensor = grid_vis_tensor[:target_grid_size, :]
+            if grid_vis_tensor.shape[1] > target_grid_size:
+                grid_vis_tensor = grid_vis_tensor[:, :target_grid_size]
+            if grid_vis_tensor.shape[0] < target_grid_size or grid_vis_tensor.shape[1] < target_grid_size:
+                # Si aún es más pequeño, usar padding con el último valor
+                pad_h = target_grid_size - grid_vis_tensor.shape[0]
+                pad_w = target_grid_size - grid_vis_tensor.shape[1]
+                grid_vis_tensor = F.pad(grid_vis_tensor, (0, pad_w, 0, pad_h), mode='replicate')
+            grid_vis = grid_vis_tensor.numpy()
 
         grid_abs = np.abs(grid_vis).reshape(-1)
         if grid_abs.size == 0:
@@ -596,7 +611,7 @@ def plot_text_image_heatmaps(
         img_vis = torch.clamp(px * std + mean, 0, 1).permute(1, 2, 0).numpy()
 
         heat_tensor = torch.as_tensor(grid_vis, dtype=torch.float32).unsqueeze(0).unsqueeze(0)
-        heat_up = F.interpolate(heat_tensor, size=(H, W), mode="bilinear", align_corners=False).squeeze().numpy()
+        heat_up = F.interpolate(heat_tensor, size=(H, W), mode="nearest").squeeze().numpy()
 
         ax_img = fig.add_subplot(gs[0, i])
         ax_img.imshow(img_vis, origin="upper", interpolation="nearest", zorder=0)

--- a/src/mmshap_medclip/vis/heatmaps.py
+++ b/src/mmshap_medclip/vis/heatmaps.py
@@ -16,7 +16,7 @@ _CLIP_MEAN = torch.tensor([0.48145466, 0.4578275, 0.40821073], dtype=torch.float
 _CLIP_STD = torch.tensor([0.26862954, 0.26130258, 0.27577711], dtype=torch.float32)
 
 PLOT_ISA_IMG_PERCENTILE = 90   # escala robusta al percentil 90
-PLOT_ISA_ALPHA_IMG = 0.50      # opacidad del overlay (reducida para mejor visibilidad)
+PLOT_ISA_ALPHA_IMG = 0.40      # opacidad del overlay (reducida para mejor visibilidad)
 PLOT_ISA_COARSEN_G = 2        # tamaño de super-parches (3x3)
 
 

--- a/src/mmshap_medclip/vis/heatmaps.py
+++ b/src/mmshap_medclip/vis/heatmaps.py
@@ -379,6 +379,9 @@ def plot_text_image_heatmaps(
         patch_h = patch_w = int(patch_size_info)
 
     _, _, H, W = inputs["pixel_values"].shape
+    
+    print(f"[DEBUG heatmaps.py] imginfo: grid_h={grid_h}, grid_w={grid_w}, patch_size={patch_size_info}")
+    print(f"[DEBUG heatmaps.py] Imagen: H={H}, W={W}")
 
     if patch_h is None and grid_h > 0:
         patch_h = max(1, int(round(H / max(grid_h, 1))))
@@ -386,7 +389,9 @@ def plot_text_image_heatmaps(
         patch_w = max(1, int(round(W / max(grid_w, 1))))
 
     if patch_h is None or patch_w is None or patch_h <= 0 or patch_w <= 0 or grid_h <= 0 or grid_w <= 0:
+        print(f"[DEBUG heatmaps.py] Inferiendo patch_size (patch_h={patch_h}, patch_w={patch_w}, grid_h={grid_h}, grid_w={grid_w})")
         ps = _infer_patch_size(model_wrapper, inputs, shap_values)
+        print(f"[DEBUG heatmaps.py] patch_size inferido: {ps}")
         if ps is None:
             raise ValueError("No pude inferir patch_size; pásalo vía model_wrapper o inputs.")
         if isinstance(ps, (list, tuple)):
@@ -400,11 +405,14 @@ def plot_text_image_heatmaps(
             patch_h = patch_w = int(ps)
         grid_h = max(1, int(round(H / max(patch_h, 1))))
         grid_w = max(1, int(round(W / max(patch_w, 1))))
+        print(f"[DEBUG heatmaps.py] Grid recalculado: grid_h={grid_h}, grid_w={grid_w} (patch_h={patch_h}, patch_w={patch_w})")
 
     patch_h = max(1, int(patch_h))
     patch_w = max(1, int(patch_w))
     side_h_base = grid_h if grid_h > 0 else None
     side_w_base = grid_w if grid_w > 0 else None
+    
+    print(f"[DEBUG heatmaps.py] Valores finales: patch_h={patch_h}, patch_w={patch_w}, side_h_base={side_h_base}, side_w_base={side_w_base}")
 
     # --- normalizar SHAP a matriz (B, L) ---
     vals = shap_values.values if hasattr(shap_values, "values") else shap_values
@@ -519,6 +527,8 @@ def plot_text_image_heatmaps(
         side_h = side_h_base if side_h_base else max(1, int(round(H / float(patch_h_eff))))
         side_w = side_w_base if side_w_base else max(1, int(round(W / float(patch_w_eff))))
         n_expected = max(1, side_h * side_w)
+        
+        print(f"[DEBUG heatmaps.py] Muestra {i}: img_slice.size={img_slice.size}, n_expected={n_expected}, side_h={side_h}, side_w={side_w}")
 
         full_vec = np.asarray(img_slice).reshape(-1)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes heatmap overlays by replicating low-res patch grids to 14×14, normalizing alpha, refining coarsening, and adding debug logs.
> 
> - **Heatmap visualization (`vis/heatmaps.py`)**:
>   - Replicate low-resolution patch grids to a target `14x14` using `repeat_interleave` (with padding/truncation) prior to coarsening; gate coarsening to only apply when grid >= target.
>   - Introduce `was_replicated` flag to slightly reduce overlay alpha for replicated grids; set consistent base alpha (`PLOT_ISA_ALPHA_IMG=0.40`).
>   - Add extensive debug logs for patch/grid inference and processing steps.
>   - Keep nearest-neighbor upsampling and robust percentile-based normalization; adjust colorbar placement logic accordingly.
> - **Comparison view (`comparison.py`)**:
>   - Apply the same grid replication to `14x14` before upsampling; use consistent overlay alpha.
>   - Add debug prints around grid replication and sizing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b16f6b7c7c61b5af47d3197a01b0b1f54302998. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->