### PR TITLE
Refactor context length handling in concat_text_image_tokens function

### DIFF
--- a/src/mmshap_medclip/tasks/utils.py
+++ b/src/mmshap_medclip/tasks/utils.py
@@ -173,12 +173,11 @@ def concat_text_image_tokens(
         inner_tok = getattr(tokenizer, "_tokenizer", tokenizer)
         context_length = getattr(inner_tok, "context_length", None)
 
-        # Si tiene context_length definido Y es mayor que los tokens reales, necesita padding
-        if context_length is not None and nb_text_tokens is not None:
-            max_real = int(nb_text_tokens.max().item())
-            # Solo usar longitud fija si el context_length es significativamente mayor
-            # (esto indica que es un modelo OpenCLIP clásico con embeddings posicionales fijos)
-            needs_fixed_length = (context_length > max_real * 1.5)
+        # Si tiene context_length definido, es un modelo OpenCLIP y necesita longitud fija
+        # Esto es crítico porque OpenCLIP tiene embeddings posicionales fijos que requieren
+        # que todos los input_ids tengan la misma longitud (context_length)
+        if context_length is not None:
+            needs_fixed_length = True
 
     # Si tenemos nb_text_tokens Y el tokenizador es flexible, usar solo tokens reales
     if nb_text_tokens is not None and not needs_fixed_length:


### PR DESCRIPTION
- Simplified the logic for determining if fixed length is needed for OpenCLIP models by removing unnecessary checks.
- Updated comments to clarify the importance of fixed input lengths for models with positional embeddings, enhancing code readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treat any tokenizer with `context_length` as fixed-length (OpenCLIP), removing heuristic checks and clarifying comments.
> 
> - **Text/Image token concatenation (`src/mmshap_medclip/tasks/utils.py`)**:
>   - Simplifies fixed-length detection in `concat_text_image_tokens`: sets `needs_fixed_length=True` whenever the tokenizer exposes `context_length`.
>   - Removes heuristic comparing `context_length` to `nb_text_tokens` and updates comments to stress OpenCLIP's fixed positional embedding requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c47af6ce6c94a5887fb109aa7e715331e7b5d56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->